### PR TITLE
Add install.sh script for easier installation and DKMS setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+MODULE_NAME="rtw88"
+MODULE_VERSION="0.6"
+SRC_DIR="$(pwd)"
+
+echo "🛠 Installing $MODULE_NAME DKMS module v$MODULE_VERSION..."
+echo
+
+# Step 1: Remove old version (if exists)
+if dkms status | grep -q "$MODULE_NAME/$MODULE_VERSION"; then
+    echo "➡️ Removing existing DKMS module..."
+    sudo dkms remove -m $MODULE_NAME -v $MODULE_VERSION --all || true
+fi
+
+# Step 2: Copy source to /usr/src
+echo "➡️ Copying source files to /usr/src/${MODULE_NAME}-${MODULE_VERSION}..."
+sudo rm -rf "/usr/src/${MODULE_NAME}-${MODULE_VERSION}"
+sudo cp -r "$SRC_DIR" "/usr/src/${MODULE_NAME}-${MODULE_VERSION}"
+
+# Step 3: DKMS operations
+echo "➡️ Adding module to DKMS..."
+sudo dkms add -m $MODULE_NAME -v $MODULE_VERSION
+
+echo "➡️ Building module..."
+sudo dkms build -m $MODULE_NAME -v $MODULE_VERSION
+
+echo "➡️ Installing module..."
+sudo dkms install -m $MODULE_NAME -v $MODULE_VERSION
+
+# Step 4: Add optional fix for ASPM
+if ! grep -q "disable_aspm=1" /etc/modprobe.d/rtw88_pci.conf 2>/dev/null; then
+    echo "➡️ Applying ASPM power stability fix..."
+    echo "options rtw88_pci disable_aspm=1" | sudo tee /etc/modprobe.d/rtw88_pci.conf
+fi
+
+echo
+echo "✅ DKMS installation complete."
+echo "🔁 Please reboot your system for changes to take effect."


### PR DESCRIPTION
### Summary

This PR adds a new `install.sh` script to automate the DKMS installation of the Realtek RTL8822CE driver on Ubuntu systems.  
It ensures the driver is properly built and installed, and also applies an ASPM fix to improve wireless stability.

### What's Included

- **`install.sh` script**:
  - Removes any existing `rtw88` DKMS module (version 0.6)
  - Copies the driver source to `/usr/src`
  - Adds, builds, and installs the DKMS module
  - Applies the ASPM power management fix using `modprobe.d`

### Tested On

- **OS**: Ubuntu 24.04.2 LTS (64-bit)
- **Kernel**: 6.11.0-26-generic
- **Wireless Chipset**: Realtek RTL8822CE (10ec:c822)
- **Driver Module**: `rtw88` with `rtw_8822ce`
- **Build Tools**: GCC 11.4, DKMS 2.8.7

### Why This is Useful

Manually setting up the driver is time-consuming and error-prone.  
This script streamlines the process by:
- Ensuring DKMS installs the driver properly
- Avoiding conflicts with power management (ASPM)
- Reducing the manual steps required for most users

